### PR TITLE
Receive request_context parameter

### DIFF
--- a/torpy/http/adapter.py
+++ b/torpy/http/adapter.py
@@ -46,13 +46,14 @@ class MyPoolManager(PoolManager):
         self._tor_info = tor_info
         super().__init__(*args, **kwargs)
 
-    def _new_pool(self, scheme, host, port):
+    def _new_pool(self, scheme, host, port, request_context=None):
         assert scheme in ['http', 'https']
-        pool_kwargs = self.connection_pool_kw.copy()
+        if request_context is None:
+            request_context = self.connection_pool_kw.copy()
         if scheme == 'http':
-            return MyHTTPConnectionPool(self._tor_info, host, port, **pool_kwargs)
+            return MyHTTPConnectionPool(self._tor_info, host, port, **request_context)
         else:
-            return MyHTTPSConnectionPool(self._tor_info, host, port, **pool_kwargs)
+            return MyHTTPSConnectionPool(self._tor_info, host, port, **request_context)
 
 
 class MyHTTPConnectionPool(HTTPConnectionPool):

--- a/torpy/http/adapter.py
+++ b/torpy/http/adapter.py
@@ -50,6 +50,9 @@ class MyPoolManager(PoolManager):
         assert scheme in ['http', 'https']
         if request_context is None:
             request_context = self.connection_pool_kw.copy()
+        request_context.pop('scheme')
+        request_context.pop('host')
+        request_context.pop('port')
         if scheme == 'http':
             return MyHTTPConnectionPool(self._tor_info, host, port, **request_context)
         else:


### PR DESCRIPTION
This PR fixes this error:
```
  File "/home/arm/.virtualenvs/ani.work/lib/python3.7/site-packages/requests/sessions.py", line 546, in get
    return self.request('GET', url, **kwargs)
  File "/home/arm/.virtualenvs/ani.work/lib/python3.7/site-packages/requests/sessions.py", line 533, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/arm/.virtualenvs/ani.work/lib/python3.7/site-packages/requests/sessions.py", line 646, in send
    r = adapter.send(request, **kwargs)
  File "/home/arm/.virtualenvs/ani.work/lib/python3.7/site-packages/requests/adapters.py", line 412, in send
    conn = self.get_connection(request.url, proxies)
  File "/home/arm/.virtualenvs/ani.work/lib/python3.7/site-packages/requests/adapters.py", line 315, in get_connection
    conn = self.poolmanager.connection_from_url(url)
  File "/home/arm/.virtualenvs/ani.work/lib/python3.7/site-packages/urllib3/poolmanager.py", line 287, in connection_from_url
    u.host, port=u.port, scheme=u.scheme, pool_kwargs=pool_kwargs
  File "/home/arm/.virtualenvs/ani.work/lib/python3.7/site-packages/urllib3/poolmanager.py", line 234, in connection_from_host
    return self.connection_from_context(request_context)
  File "/home/arm/.virtualenvs/ani.work/lib/python3.7/site-packages/urllib3/poolmanager.py", line 247, in connection_from_context
    return self.connection_from_pool_key(pool_key, request_context=request_context)
  File "/home/arm/.virtualenvs/ani.work/lib/python3.7/site-packages/urllib3/poolmanager.py", line 269, in connection_from_pool_key
    pool = self._new_pool(scheme, host, port, request_context=request_context)
TypeError: _new_pool() got an unexpected keyword argument 'request_context'
```
