### PR TITLE
Fixes for Python 3.12

### DIFF
--- a/torpy/cell_socket.py
+++ b/torpy/cell_socket.py
@@ -54,9 +54,8 @@ class TorCellSocket:
         if self._socket:
             raise Exception('Already connected')
 
-        self._socket = ssl.wrap_socket(
-            socket.socket(socket.AF_INET, socket.SOCK_STREAM), ssl_version=ssl.PROTOCOL_TLSv1_2
-        )
+        context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+        self._socket = context.wrap_socket(socket.socket(socket.AF_INET, socket.SOCK_STREAM))
         logger.debug('Connecting socket to %s relay...', self._router)
         try:
             self._socket.settimeout(15.0)

--- a/torpy/http/adapter.py
+++ b/torpy/http/adapter.py
@@ -43,7 +43,7 @@ class TorHttpAdapter(HTTPAdapter):
         self._pool_block = block
 
         self.poolmanager = MyPoolManager(
-            self._tor_info, num_pools=connections, maxsize=maxsize, block=block, strict=True, **pool_kwargs
+            self._tor_info, num_pools=connections, maxsize=maxsize, block=block, **pool_kwargs
         )
 
 
@@ -85,7 +85,6 @@ class MyHTTPConnectionPool(HTTPConnectionPool):
             host=self.host,
             port=self.port,
             timeout=self.timeout.connect_timeout,
-            strict=self.strict,
             **self.conn_kw,
         )
 
@@ -104,7 +103,6 @@ class MyHTTPSConnectionPool(HTTPSConnectionPool):
             host=self.host,
             port=self.port,
             timeout=self.timeout.connect_timeout,
-            strict=self.strict,
             **self.conn_kw,
         )
         logger.debug('[MyHTTPSConnectionPool] preparing...')


### PR DESCRIPTION
Two fixes for Python 3.12, removing the use of obsolete API.

Resolves #53.